### PR TITLE
add some more context to the items of WETO funding and 'stack'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 # WETOStack
 
-This repository contains the source files for the documentation of the WETO Software Stack, which includes an entry guide for new users, multiple listings and categorization of the software models, software quality characterization, and notes from the developer and user engagement that created the WETOStack content. See [nrel.github.io/WETOStack/](https://nrel.github.io/WETOStack/) for more information.
+This repository contains the source files for the documentation of the WETO Software Stack, a software portfolio wholly or partially supported by the Department of Energy's [Wind Energy Technologies Office (WETO)](https://www.energy.gov/eere/wind/wind-energy-technologies-office).  The source files include an entry guide for new users, multiple listings and categorization of the software models, software quality characterization, and notes from the developer and user engagement that created the WETOStack content. See [nrel.github.io/WETOStack/](https://nrel.github.io/WETOStack/) for more information.
+
+Note that while a "software stack" usually refers to a set of integrated software codes, the portfolio of codes in the WETO Stack is diverse and can be used individually or integrated, depending on the use case. 
 
 Copyright 2024 Alliance for Sustainable Energy, LLC.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # WETO Software Stack
 
-The WETO Software Stack is the software portfolio supported by the Department of Energy's [Wind Energy Technologies Office (WETO)](https://www.energy.gov/eere/wind/wind-energy-technologies-office).  Through the national laboratories and their univeristy collaborators, this portfolio includes engineering and techno-economic models focused on wind energy across a spectrum of model fidelities and use cases.
+The WETO Software Stack is the software portfolio wholly or partially supported by the Department of Energy's [Wind Energy Technologies Office (WETO)](https://www.energy.gov/eere/wind/wind-energy-technologies-office).  Through the national laboratories and their univeristy collaborators, this portfolio includes engineering and techno-economic models focused on wind energy across a spectrum of model fidelities and use cases.  While a "software stack" usually refers to a set of integrated software codes, the portfolio of codes in the WETO Stack is diverse and can be used individually or integrated, depending on the use case. 
 
 Please use the navigation at the left or below to jump to your desired content.  If you are a new user looking to find the right tool for your application, please see the Entry Guide.
 


### PR DESCRIPTION
Adding context that WETO can be a partial funder, not just sole funder, of the codes.  Also clarify that "Stack" here is just catchy and doesn't imply a "software stack" as commonly understood in the software development world.